### PR TITLE
Add Notion webhook route to middleware for public access

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,7 @@ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
 const isPublicRoute = createRouteMatcher([
   '/',
   '/api/webhook/clerk',
+  '/api/webhooks/notion', // Notion webhook (no auth; verified via NOTION_WEBHOOK_SECRET)
   '/api/notion/daily-tracking',
   '/api/spotify/callback',
   '/api/google-calendar/callback',


### PR DESCRIPTION
- Included '/api/webhooks/notion' in the public route matcher to allow unauthenticated access for Notion webhooks, verified via NOTION_WEBHOOK_SECRET. This enhances integration with Notion while maintaining security for other routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Notion webhook integration, enabling external events to be received and processed securely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->