### PR TITLE
Add logging for Notion webhook verification token

### DIFF
--- a/src/app/api/webhooks/notion/route.ts
+++ b/src/app/api/webhooks/notion/route.ts
@@ -30,6 +30,8 @@ export async function POST(request: NextRequest) {
 
     // Step 1: Subscription verification — Notion sends a one-time payload with verification_token
     if (body.verification_token != null && Object.keys(body).length <= 2) {
+      const token = body.verification_token as string;
+      console.log('[Notion webhook] Paste this into .env as NOTION_WEBHOOK_SECRET:', token);
       return NextResponse.json({ ok: true }, { status: 200 });
     }
 


### PR DESCRIPTION
- Implemented a console log to output the verification token received from Notion, guiding users to store it in the .env file as NOTION_WEBHOOK_SECRET. This change aids in the setup process for integrating Notion webhooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Notion webhook verification setup with improved configuration guidance through logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->